### PR TITLE
Correct open/close behavior in milestone edit form

### DIFF
--- a/src/main/twirl/gitbucket/core/issues/milestones/edit.scala.html
+++ b/src/main/twirl/gitbucket/core/issues/milestones/edit.scala.html
@@ -29,9 +29,9 @@
           <input type="submit" class="btn btn-success" value="Create milestone"/>
         } else {
           @if(milestone.get.closedDate.isDefined){
-            <input type="button" class="btn btn-default" value="Open" id="open" onclick="location.href='@helpers.url(repository)/issues/milestones/@milestone.get.milestoneId/close';"/>
+            <input type="button" class="btn btn-default" value="Open" id="open" onclick="location.href='@helpers.url(repository)/issues/milestones/@milestone.get.milestoneId/open';"/>
           } else {
-            <input type="button" class="btn btn-default" value="Close" id="close" onclick="location.href='@helpers.url(repository)/issues/milestones/@milestone.get.milestoneId/open';"/>
+            <input type="button" class="btn btn-default" value="Close" id="close" onclick="location.href='@helpers.url(repository)/issues/milestones/@milestone.get.milestoneId/close';"/>
           }
           <input type="submit" class="btn btn-success" value="Update milestone"/>
         }


### PR DESCRIPTION
### Before submitting a pull-request to GitBucket I have first:

- [ ] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [ ] rebased my branch over master
- [ ] verified that project is compiling
- [ ] verified that tests are passing
- [ ] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
